### PR TITLE
Skipping couple of btrfs Tests

### DIFF
--- a/fs/xfstests.py.data/btrfs/4k_auto_upstream.yaml
+++ b/fs/xfstests.py.data/btrfs/4k_auto_upstream.yaml
@@ -12,7 +12,7 @@ loop_type: !mux
 fs_type: !mux
     fs_btrfs_4k_auto:
         fs: 'btrfs'
-        args: '-R xunit -L 10 -g auto'
+        args: '-e btrfs/063,btrfs/132 -R xunit -L 10 -g auto'
         mkfs_opt: '-f -s 4096'
         mount_opt: ''
 


### PR DESCRIPTION
Currently, there is some issues with btrfs test suite, which is causing test to stuck at btrfs/063 and btrfs/132. Hence skipping these two tests, until there is a fix.